### PR TITLE
Add robots.txt to sitemap resources

### DIFF
--- a/lib/middleman-robots/extension.rb
+++ b/lib/middleman-robots/extension.rb
@@ -65,6 +65,15 @@ module Middleman
       def sitemap(path)
         path ? "Sitemap: #{path}" : ''
       end
+
+      def manipulate_resource_list(resources)
+        resources << Middleman::Sitemap::Resource.new(app.sitemap, 'robots.txt', source)
+      end
+
+      def source
+        templates_dir = File.expand_path(File.join('..', 'templates'), __FILE__)
+        File.join(templates_dir, 'robots.txt')
+      end
     end
   end
 end

--- a/lib/middleman-robots/templates/robots.txt
+++ b/lib/middleman-robots/templates/robots.txt
@@ -1,0 +1,1 @@
+This is dummy robots.txt template (overwritten when building)


### PR DESCRIPTION
I've added `robots.txt` to Middleman's sitemap resources as some other extensions require source files to be in a sitemap (e.g. [middleman-s3_sync](https://github.com/fredjean/middleman-s3_sync) just ignores files which are not in a sitemap) .