### PR TITLE
fix #8 using /tmp/robots/robots.txt instead of tempfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /spec/reports/
 /tmp/*
 !/tmp/robots/
+/tmp/robots/*
 /vendor
 *.bundle
 *.so

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,8 @@
 /doc/
 /pkg/
 /spec/reports/
-/tmp/
+/tmp/*
+!/tmp/robots/
 /vendor
 *.bundle
 *.so

--- a/lib/middleman-robots/extension.rb
+++ b/lib/middleman-robots/extension.rb
@@ -9,15 +9,16 @@ module Middleman
       option :sitemap, false, 'URI of sitemap.xml'
 
       def manipulate_resource_list(resources)
-        tf = Tempfile.open('middleman-robots')
-        tf.puts(Generator.new(options.rules, options.sitemap).process)
+        tmp_path = File.expand_path('../../../tmp/robots/robots.txt', __FILE__)
+        File.open(tmp_path, 'w+') do |f|
+          f.puts(Generator.new(options.rules, options.sitemap).process)
+        end
 
         robots = Middleman::Sitemap::Resource.new(
           app.sitemap,
           'robots.txt',
-          tf.path
+          tmp_path
         )
-        tf.close
 
         logger.info '== middleman-robots: robots.txt added to resources =='
         resources << robots


### PR DESCRIPTION
In v1.3.1 there seems to be an error regarding tempfile. https://github.com/yterajima/middleman-robots/issues/8