### PR TITLE
Relax middleman dependencies to ~>4.0

### DIFF
--- a/middleman-robots.gemspec
+++ b/middleman-robots.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6.0'
 
-  spec.add_runtime_dependency 'middleman-cli', '>= 4.0', '<= 4.4'
-  spec.add_runtime_dependency 'middleman-core', '>= 4.0', '<= 4.4'
+  spec.add_runtime_dependency 'middleman-cli', '~> 4.0'
+  spec.add_runtime_dependency 'middleman-core', '~> 4.0'
 
   spec.add_development_dependency 'aruba', '>= 0.14.3'
   spec.add_development_dependency 'bundler', '>= 1.16'


### PR DESCRIPTION
On Nov 3, 2021 Middleman version 4.4.2 was released that does not
satisfy the constraints '>= 4.0' and '<= 4.4'.